### PR TITLE
Enable Firebird 3 on Debian Trixie and Ubuntu Noble

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ src/README.md.template         # README generator
 - Use `{{VAR}}` template syntax (simple string replacement). Never `<% %>` or `ExpandString`.
 - PSFirebird v1.0.0+ from PSGallery is a dependency. Do NOT reference `./tmp/PSFirebird/`.
 - `./tmp/` is for temporary files only. Never commit or reference in production code.
-- Default distro: `bookworm`. Blocked: FB3 + noble (no libncurses5).
+- Default distro: `bookworm`. Blocked: none.
 - ARM64 only for Firebird 5+. No QEMU — use native ARM64 GitHub runners.
 - All tags computed deterministically from version matrix via `Get-ImageTags`.
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -50,6 +50,8 @@ Decisions made during the v2 rewrite, with rationale.
 
 **Rationale:** Firebird 3 depends on `libncurses5`, which was removed from Ubuntu Noble. Rather than special-casing in code, we declare blocked combinations in config.
 
+**Amended by D-017** for the FB3 + (Noble | Trixie) carve-out: the mechanism remains, but the FB3 entries have been cleared and the missing dependency is now provisioned in the template.
+
 ## D-008: Fork CI scope — latest release per major version
 
 **Decision:** On forks (non-official repo, non-`workflow_dispatch`), CI builds and tests only the latest release of each major Firebird version (e.g. 5.0.3, 4.0.6, 3.0.13). The official repository always performs a full build of all versions.
@@ -103,3 +105,11 @@ Decisions made during the v2 rewrite, with rationale.
 **Decision:** In `init_db()`, run plain SQL files as `cat "$f" | process_sql`, not `process_sql < "$f"`.
 
 **Rationale:** `isql` reads stdin one byte per `read()` syscall (no stdio buffer is set up on stdin). With `cat | isql`, those byte-reads come from a kernel pipe (in-memory, lock-free). With `isql < file`, every byte-read goes through the regular-file path (i_rwsem, atime, FS layer). On native disk this is a ~25 % cost on init.d-driven schema loads; on layered or remote filesystems (Docker Desktop bind mounts on macOS/Windows, gRPC FUSE / virtiofs, NFS) per-syscall overhead amplifies it into 10×+ slowdowns — see [issue #40](https://github.com/FirebirdSQL/firebird-docker/issues/40). The pipe form is also consistent with the compressed cases (`*.sql.gz`, `*.sql.xz`, `*.sql.zst`) which already use a decompressor pipeline. `process_sql` itself stays redirect-friendly so callers other than `init_db` are unaffected.
+
+## D-017: Re-enable Firebird 3 on Trixie and Noble via .deb side-load
+
+**Decision:** Stop excluding `noble` and `trixie` from FB3 builds. Provision `libncurses5`/`libtinfo5` for FB3 by downloading the corresponding `.deb` files from the bookworm (for Trixie) and jammy (for Noble) archive pools and installing them with `dpkg -i`. Clears `blockedVariants["3"]`.
+
+**Rationale:** D-007 declared FB3+Noble unsupportable because `libncurses5` had been dropped from Noble's apt sources, and chose a config-level block over template special-casing. Debian Trixie has since dropped the same packages, which would have required adding Trixie to the block list — defeating the intent of D-012 (Trixie as default distro). The FB3 binaries' only remaining unresolved dependencies on Trixie/Noble are `libncurses.so.5` and `libtinfo.so.5` (verified by `ldd`); the corresponding `.deb` files are still served by the bookworm and jammy archive pools and install cleanly. The workaround is localized to one `RUN` block in the template, gated on `FIREBIRD_MAJOR == 3` and keyed off `/etc/os-release`. Supersedes the FB3 + (Noble | Trixie) clause of D-007. See [issue #42](https://github.com/FirebirdSQL/firebird-docker/issues/42).
+
+Also adds `tzdata` to Noble's distro `extraPackages` (matching Jammy). FB3 relies on libc `localtime()` for the `TZ` env var, which requires `/usr/share/zoneinfo` — the Ubuntu Noble base image, like Jammy, ships without it. FB4+ embeds its own zoneinfo and is unaffected, which is why the gap surfaced only when re-enabling FB3 builds on Noble.

--- a/README.md
+++ b/README.md
@@ -87,24 +87,34 @@ Docker images for Firebird Database.
 |`3.0.14-bookworm`, `3-bookworm`|[Dockerfile](./generated/3.0.14/bookworm/Dockerfile)|
 |`3.0.14-bullseye`, `3-bullseye`|[Dockerfile](./generated/3.0.14/bullseye/Dockerfile)|
 |`3.0.14-jammy`, `3-jammy`|[Dockerfile](./generated/3.0.14/jammy/Dockerfile)|
+|`3.0.14-noble`, `3-noble`|[Dockerfile](./generated/3.0.14/noble/Dockerfile)|
+|`3.0.14-trixie`, `3-trixie`, `3.0.14`, `3`|[Dockerfile](./generated/3.0.14/trixie/Dockerfile)|
 |`3.0.13-bookworm`|[Dockerfile](./generated/3.0.13/bookworm/Dockerfile)|
 |`3.0.13-bullseye`|[Dockerfile](./generated/3.0.13/bullseye/Dockerfile)|
 |`3.0.13-jammy`|[Dockerfile](./generated/3.0.13/jammy/Dockerfile)|
+|`3.0.13-noble`|[Dockerfile](./generated/3.0.13/noble/Dockerfile)|
+|`3.0.13-trixie`, `3.0.13`|[Dockerfile](./generated/3.0.13/trixie/Dockerfile)|
 |`3.0.12-bookworm`|[Dockerfile](./generated/3.0.12/bookworm/Dockerfile)|
 |`3.0.12-bullseye`|[Dockerfile](./generated/3.0.12/bullseye/Dockerfile)|
 |`3.0.12-jammy`|[Dockerfile](./generated/3.0.12/jammy/Dockerfile)|
+|`3.0.12-noble`|[Dockerfile](./generated/3.0.12/noble/Dockerfile)|
+|`3.0.12-trixie`, `3.0.12`|[Dockerfile](./generated/3.0.12/trixie/Dockerfile)|
 |`3.0.11-bookworm`|[Dockerfile](./generated/3.0.11/bookworm/Dockerfile)|
 |`3.0.11-bullseye`|[Dockerfile](./generated/3.0.11/bullseye/Dockerfile)|
 |`3.0.11-jammy`|[Dockerfile](./generated/3.0.11/jammy/Dockerfile)|
+|`3.0.11-noble`|[Dockerfile](./generated/3.0.11/noble/Dockerfile)|
+|`3.0.11-trixie`, `3.0.11`|[Dockerfile](./generated/3.0.11/trixie/Dockerfile)|
 |`3.0.10-bookworm`|[Dockerfile](./generated/3.0.10/bookworm/Dockerfile)|
 |`3.0.10-bullseye`|[Dockerfile](./generated/3.0.10/bullseye/Dockerfile)|
 |`3.0.10-jammy`|[Dockerfile](./generated/3.0.10/jammy/Dockerfile)|
+|`3.0.10-noble`|[Dockerfile](./generated/3.0.10/noble/Dockerfile)|
+|`3.0.10-trixie`, `3.0.10`|[Dockerfile](./generated/3.0.10/trixie/Dockerfile)|
 |`3.0.9-bookworm`|[Dockerfile](./generated/3.0.9/bookworm/Dockerfile)|
 |`3.0.9-bullseye`|[Dockerfile](./generated/3.0.9/bullseye/Dockerfile)|
 |`3.0.9-jammy`|[Dockerfile](./generated/3.0.9/jammy/Dockerfile)|
+|`3.0.9-noble`|[Dockerfile](./generated/3.0.9/noble/Dockerfile)|
+|`3.0.9-trixie`, `3.0.9`|[Dockerfile](./generated/3.0.9/trixie/Dockerfile)|
 
-
-> _Firebird 3 does not have an image for Ubuntu 24.04 LTS (Noble Numbat) due to a dependency (`libncurses5`) missing from Ubuntu sources._
 
 
 ## Snapshot (pre-release) images

--- a/assets.json
+++ b/assets.json
@@ -20,7 +20,7 @@
       "noble": {
         "baseImage": "ubuntu:noble",
         "icuPackage": "libicu74",
-        "extraPackages": ""
+        "extraPackages": "tzdata"
       },
       "trixie": {
         "baseImage": "debian:trixie-slim",
@@ -28,12 +28,7 @@
         "extraPackages": ""
       }
     },
-    "blockedVariants": {
-      "3": [
-        "noble",
-        "trixie"
-      ]
-    }
+    "blockedVariants": {}
   },
   "versions": [
     {
@@ -357,6 +352,16 @@
         "jammy": [
           "3.0.14-jammy",
           "3-jammy"
+        ],
+        "noble": [
+          "3.0.14-noble",
+          "3-noble"
+        ],
+        "trixie": [
+          "3.0.14-trixie",
+          "3-trixie",
+          "3.0.14",
+          "3"
         ]
       }
     },
@@ -371,7 +376,12 @@
       "tags": {
         "bookworm": "3.0.13-bookworm",
         "bullseye": "3.0.13-bullseye",
-        "jammy": "3.0.13-jammy"
+        "jammy": "3.0.13-jammy",
+        "noble": "3.0.13-noble",
+        "trixie": [
+          "3.0.13-trixie",
+          "3.0.13"
+        ]
       }
     },
     {
@@ -385,7 +395,12 @@
       "tags": {
         "bookworm": "3.0.12-bookworm",
         "bullseye": "3.0.12-bullseye",
-        "jammy": "3.0.12-jammy"
+        "jammy": "3.0.12-jammy",
+        "noble": "3.0.12-noble",
+        "trixie": [
+          "3.0.12-trixie",
+          "3.0.12"
+        ]
       }
     },
     {
@@ -399,7 +414,12 @@
       "tags": {
         "bookworm": "3.0.11-bookworm",
         "bullseye": "3.0.11-bullseye",
-        "jammy": "3.0.11-jammy"
+        "jammy": "3.0.11-jammy",
+        "noble": "3.0.11-noble",
+        "trixie": [
+          "3.0.11-trixie",
+          "3.0.11"
+        ]
       }
     },
     {
@@ -413,7 +433,12 @@
       "tags": {
         "bookworm": "3.0.10-bookworm",
         "bullseye": "3.0.10-bullseye",
-        "jammy": "3.0.10-jammy"
+        "jammy": "3.0.10-jammy",
+        "noble": "3.0.10-noble",
+        "trixie": [
+          "3.0.10-trixie",
+          "3.0.10"
+        ]
       }
     },
     {
@@ -427,7 +452,12 @@
       "tags": {
         "bookworm": "3.0.9-bookworm",
         "bullseye": "3.0.9-bullseye",
-        "jammy": "3.0.9-jammy"
+        "jammy": "3.0.9-jammy",
+        "noble": "3.0.9-noble",
+        "trixie": [
+          "3.0.9-trixie",
+          "3.0.9"
+        ]
       }
     }
   ]

--- a/generated/3.0.10/bookworm/Dockerfile
+++ b/generated/3.0.10/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.10/bullseye/Dockerfile
+++ b/generated/3.0.10/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.10/jammy/Dockerfile
+++ b/generated/3.0.10/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.10/noble/Dockerfile
+++ b/generated/3.0.10/noble/Dockerfile
@@ -1,0 +1,143 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM ubuntu:noble
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.10
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu74 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        tzdata \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.10/Firebird-3.0.10.33601-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='5e0db3b9312c5bed3eccd1855ec07df5a50176dbff35b8ebf998360b59561cf0'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.10/noble/entrypoint.sh
+++ b/generated/3.0.10/noble/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/3.0.10/trixie/Dockerfile
+++ b/generated/3.0.10/trixie/Dockerfile
@@ -1,0 +1,142 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM debian:trixie-slim
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.10
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu76 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.10/Firebird-3.0.10.33601-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='5e0db3b9312c5bed3eccd1855ec07df5a50176dbff35b8ebf998360b59561cf0'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.10/trixie/entrypoint.sh
+++ b/generated/3.0.10/trixie/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/3.0.11/bookworm/Dockerfile
+++ b/generated/3.0.11/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.11/bullseye/Dockerfile
+++ b/generated/3.0.11/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.11/jammy/Dockerfile
+++ b/generated/3.0.11/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.11/noble/Dockerfile
+++ b/generated/3.0.11/noble/Dockerfile
@@ -1,0 +1,143 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM ubuntu:noble
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.11
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu74 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        tzdata \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.11/Firebird-3.0.11.33703-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='713757e09b40b2631d800dacd9b80179b7eb75693a72089136055a7154413a3e'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.11/noble/entrypoint.sh
+++ b/generated/3.0.11/noble/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/3.0.11/trixie/Dockerfile
+++ b/generated/3.0.11/trixie/Dockerfile
@@ -1,0 +1,142 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM debian:trixie-slim
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.11
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu76 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.11/Firebird-3.0.11.33703-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='713757e09b40b2631d800dacd9b80179b7eb75693a72089136055a7154413a3e'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.11/trixie/entrypoint.sh
+++ b/generated/3.0.11/trixie/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/3.0.12/bookworm/Dockerfile
+++ b/generated/3.0.12/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.12/bullseye/Dockerfile
+++ b/generated/3.0.12/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.12/jammy/Dockerfile
+++ b/generated/3.0.12/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.12/noble/Dockerfile
+++ b/generated/3.0.12/noble/Dockerfile
@@ -1,0 +1,143 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM ubuntu:noble
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.12
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu74 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        tzdata \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.12/Firebird-3.0.12.33787-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='406a8887ab318a5d8a20781fc1d38a0ca30acdbddbc1558b077646bb2e2e283f'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.12/noble/entrypoint.sh
+++ b/generated/3.0.12/noble/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/3.0.12/trixie/Dockerfile
+++ b/generated/3.0.12/trixie/Dockerfile
@@ -1,0 +1,142 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM debian:trixie-slim
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.12
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu76 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.12/Firebird-3.0.12.33787-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='406a8887ab318a5d8a20781fc1d38a0ca30acdbddbc1558b077646bb2e2e283f'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.12/trixie/entrypoint.sh
+++ b/generated/3.0.12/trixie/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/3.0.13/bookworm/Dockerfile
+++ b/generated/3.0.13/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.13/bullseye/Dockerfile
+++ b/generated/3.0.13/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.13/jammy/Dockerfile
+++ b/generated/3.0.13/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.13/noble/Dockerfile
+++ b/generated/3.0.13/noble/Dockerfile
@@ -1,0 +1,143 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM ubuntu:noble
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.13
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu74 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        tzdata \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.13/Firebird-3.0.13.33818-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='677e19d6308869d5dd0836a342157c7bd1e4b5a873aa385832da01d81db444dd'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.13/noble/entrypoint.sh
+++ b/generated/3.0.13/noble/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/3.0.13/trixie/Dockerfile
+++ b/generated/3.0.13/trixie/Dockerfile
@@ -1,0 +1,142 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM debian:trixie-slim
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.13
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu76 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.13/Firebird-3.0.13.33818-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='677e19d6308869d5dd0836a342157c7bd1e4b5a873aa385832da01d81db444dd'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.13/trixie/entrypoint.sh
+++ b/generated/3.0.13/trixie/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/3.0.14/bookworm/Dockerfile
+++ b/generated/3.0.14/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.14/bullseye/Dockerfile
+++ b/generated/3.0.14/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.14/jammy/Dockerfile
+++ b/generated/3.0.14/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.14/noble/Dockerfile
+++ b/generated/3.0.14/noble/Dockerfile
@@ -1,0 +1,143 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM ubuntu:noble
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.14
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu74 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        tzdata \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.14/Firebird-3.0.14.33856-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='d6fedba1108a46cea2b5f753674046fff0e43c6af27ba01657511635cbc9670f'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.14/noble/entrypoint.sh
+++ b/generated/3.0.14/noble/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/3.0.14/trixie/Dockerfile
+++ b/generated/3.0.14/trixie/Dockerfile
@@ -1,0 +1,142 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM debian:trixie-slim
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.14
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu76 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.14/Firebird-3.0.14.33856-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='d6fedba1108a46cea2b5f753674046fff0e43c6af27ba01657511635cbc9670f'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.14/trixie/entrypoint.sh
+++ b/generated/3.0.14/trixie/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/3.0.9/bookworm/Dockerfile
+++ b/generated/3.0.9/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.9/bullseye/Dockerfile
+++ b/generated/3.0.9/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.9/jammy/Dockerfile
+++ b/generated/3.0.9/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=3
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/3.0.9/noble/Dockerfile
+++ b/generated/3.0.9/noble/Dockerfile
@@ -1,0 +1,143 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM ubuntu:noble
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.9
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu74 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        tzdata \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.9/Firebird-3.0.9.33560-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='0a80a5dc507f388e96adf9b64584c0b568d94a8f3df19d7baec494c5f98ba5a4'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.9/noble/entrypoint.sh
+++ b/generated/3.0.9/noble/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/3.0.9/trixie/Dockerfile
+++ b/generated/3.0.9/trixie/Dockerfile
@@ -1,0 +1,142 @@
+#
+# This file was auto-generated. Do not edit. See /src.
+#
+
+# Best practices for Dockerfile instructions
+#   https://docs.docker.com/develop/develop-images/instructions/
+
+FROM debian:trixie-slim
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV FIREBIRD_VERSION=3.0.9
+ENV FIREBIRD_MAJOR=3
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -x  Print commands and their arguments as they are executed.
+
+# Prerequisites
+RUN set -eux; \
+    apt-get update; \
+    # Install prerequisites + tini + curl/ca-certificates for download
+    apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libicu76 \
+        libncurses6 \
+        libtomcrypt1 \
+        libtommath1 \
+        netbase \
+        procps \
+        tini \
+        ca-certificates \
+        curl; \
+    \
+    # Download
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+        amd64) \
+            FIREBIRD_URL='https://github.com/FirebirdSQL/firebird/releases/download/v3.0.9/Firebird-3.0.9.33560-0.amd64.tar.gz'; \
+            FIREBIRD_SHA256='0a80a5dc507f388e96adf9b64584c0b568d94a8f3df19d7baec494c5f98ba5a4'; \
+            ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/firebird_install; \
+    echo "Downloading Firebird from $FIREBIRD_URL"; \
+    curl -fSL "$FIREBIRD_URL" -o /tmp/firebird_install/firebird-bundle.tar.gz; \
+    echo "Verifying checksum: $FIREBIRD_SHA256 for downloaded file"; \
+    echo "$FIREBIRD_SHA256 /tmp/firebird_install/firebird-bundle.tar.gz" | sha256sum -c -; \
+    \
+    # Extract, install, clean
+    cd /tmp/firebird_install; \
+    tar --extract --file=firebird-bundle.tar.gz --gunzip --verbose --strip-components=1; \
+    ./install.sh -silent; \
+    rm -rf /tmp/firebird_install; \
+    # Remove unnecessary files
+    rm -rf /opt/firebird/doc \
+           /opt/firebird/examples \
+           /opt/firebird/help \
+           /opt/firebird/include; \
+    # Remove 'employee' sample database from 'databases.conf'
+    sed -i '/^employee/d' /opt/firebird/databases.conf; \
+    \
+    # Clean up temporary packages (curl, ca-certificates) and apt lists
+    apt-get purge -y --auto-remove curl ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix libtommath for FB 3.0 -- https://github.com/FirebirdSQL/firebird/issues/5716#issuecomment-826239174
+RUN set -eux; \
+    ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
+    [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
+
+# System path
+ENV PATH=/opt/firebird/bin:$PATH
+
+# Data directory
+ENV FIREBIRD_DATA=/var/lib/firebird/data
+RUN set -eux; \
+    mkdir -p "$FIREBIRD_DATA"; \
+    chown -R firebird:firebird "$FIREBIRD_DATA"; \
+    chmod 755 "$FIREBIRD_DATA"
+VOLUME $FIREBIRD_DATA
+
+# Entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN set -eux; \
+    chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]
+
+STOPSIGNAL SIGTERM
+EXPOSE 3050/tcp
+
+# Fix terminfo location
+ENV TERMINFO=/lib/terminfo/
+
+CMD ["firebird"]
+

--- a/generated/3.0.9/trixie/entrypoint.sh
+++ b/generated/3.0.9/trixie/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+#
+# Docker entrypoint for firebird-docker images.
+#
+# Based on works of Jacob Alberty and The PostgreSQL Development Group.
+#
+
+#
+# About the [Tabs ahead] marker:
+#   Some sections of this file use tabs for better readability.
+#   When using bash here strings the - option suppresses leading tabs but not spaces.
+#
+
+
+
+# https://linuxcommand.org/lc3_man_pages/seth.html
+#   -E  If set, the ERR trap is inherited by shell functions.
+#   -e  Exit immediately if a command exits with a non-zero status.
+#   -u  Treat unset variables as an error when substituting
+#   -o  Set the variable corresponding to option-name:
+#       pipefail     the return value of a pipeline is the status of
+#                    the last command to exit with a non-zero status,
+#                    or zero if no command exited with a non-zero status
+set -Eeuo pipefail
+
+# usage: read_from_file_or_env VAR [DEFAULT]
+#    ie: read_from_file_or_env 'DB_PASSWORD' 'example'
+# If $(VAR)_FILE var is set, sets VAR value from file contents. Otherwise, uses DEFAULT value if VAR is not set.
+read_from_file_or_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: Both $var and $fileVar are set.
+			
+			       Variables $var and $fileVar are mutually exclusive. Remove either one.
+			-----
+		EOL
+        exit 1
+    fi
+
+    local def="${2:-}"
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# usage: escape_sql_string STR
+#    ie: escape_sql_string "it's_me"
+# Escapes single quotes for safe SQL interpolation.
+escape_sql_string() {
+    printf '%s' "${1//\'/\'\'}"
+}
+
+# usage: firebird_config_set KEY VALUE
+#    ie: firebird_config_set 'WireCrypt' 'Enabled'
+# Set configuration key KEY to VALUE in 'firebird.conf'
+firebird_config_set() {
+    # Uncomment line
+    sed -i "s/^#${1}/${1}/g" /opt/firebird/firebird.conf
+
+    # Set KEY to VALUE
+    sed -i "s~^\(${1}\s*=\s*\).*$~\1${2}~" /opt/firebird/firebird.conf
+}
+
+# Indent multi-line string -- https://stackoverflow.com/a/29779745
+indent() {
+    sed 's/^/    /';
+}
+
+# Set Firebird configuration parameters from environment variables.
+set_config() {
+    read_from_file_or_env 'FIREBIRD_USE_LEGACY_AUTH'
+    if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+        echo 'Using Legacy_Auth.'
+
+        # Firebird 4+: Uses 'Srp256' before 'Srp'.
+        local srp256=''
+        [ "$FIREBIRD_MAJOR" -ge "4" ] && srp256='Srp256, '
+
+        # Adds Legacy_Auth and Legacy_UserManager as first options.
+        firebird_config_set AuthServer "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set AuthClient "Legacy_Auth, ${srp256}Srp"
+        firebird_config_set UserManager 'Legacy_UserManager, Srp'
+
+        # Default setting is 'Required'. Reduces it to 'Enabled'.
+        firebird_config_set WireCrypt 'Enabled'
+    fi
+
+    # FIREBIRD_CONF_* variables: set key in 'firebird.conf'
+    local v
+    for v in $(compgen -A variable | grep 'FIREBIRD_CONF_'); do
+        local key=${v/FIREBIRD_CONF_/}
+        firebird_config_set "$key" "${!v}"
+    done
+
+    # Output changed settings
+    local changed_settings
+    changed_settings=$(grep -o '^[^#]*' /opt/firebird/firebird.conf) || true
+    if [ -n "$changed_settings" ]; then
+        echo "Using settings:"
+        echo "$changed_settings" | indent
+    fi
+}
+
+# Changes SYSDBA password if FIREBIRD_ROOT_PASSWORD variable is set.
+set_sysdba() {
+    read_from_file_or_env 'FIREBIRD_ROOT_PASSWORD'
+    if [ -n "$FIREBIRD_ROOT_PASSWORD" ]; then
+        echo 'Changing SYSDBA password.'
+
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_ROOT_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+			CREATE OR ALTER USER SYSDBA
+			    PASSWORD '${escaped_password}'
+			    USING PLUGIN Srp;
+			EXIT;
+		EOL
+
+        if [ "$FIREBIRD_USE_LEGACY_AUTH" == 'true' ]; then
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -user SYSDBA security.db <<-EOL
+				CREATE OR ALTER USER SYSDBA
+				    PASSWORD '${escaped_password}'
+				    USING PLUGIN Legacy_UserManager;
+				EXIT;
+			EOL
+        fi
+
+        rm -rf /opt/firebird/SYSDBA.password
+    fi
+}
+
+# Requires FIREBIRD_PASSWORD if FIREBIRD_USER is set.
+requires_user_password() {
+    if [ -n "$FIREBIRD_USER" ] && [ -z "$FIREBIRD_PASSWORD" ]; then
+        # [Tabs ahead]
+        cat >&2 <<-EOL
+			-----
+			ERROR: FIREBIRD_PASSWORD variable is not set.
+			
+			       When using FIREBIRD_USER you must also set FIREBIRD_PASSWORD variable.
+			-----
+		EOL
+        exit 1
+    fi
+}
+
+# Create Firebird user.
+create_user() {
+    read_from_file_or_env 'FIREBIRD_USER'
+    read_from_file_or_env 'FIREBIRD_PASSWORD'
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        requires_user_password
+        echo "Creating user '$FIREBIRD_USER'..."
+
+        local escaped_user
+        escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+        local escaped_password
+        escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+
+        # [Tabs ahead]
+        /opt/firebird/bin/isql -b security.db <<-EOL
+			CREATE OR ALTER USER ${escaped_user}
+			    PASSWORD '${escaped_password}'
+			    GRANT ADMIN ROLE;
+			EXIT;
+		EOL
+    fi
+}
+
+# Run isql
+process_sql() {
+	local isql_command=( /opt/firebird/bin/isql -b )
+
+    if [ -n "$FIREBIRD_USER" ]; then
+        isql_command+=( -u "$FIREBIRD_USER" -p "$FIREBIRD_PASSWORD" )
+	fi
+
+	if [ -n "$FIREBIRD_DATABASE" ]; then
+		isql_command+=( "$FIREBIRD_DATABASE" )
+	fi
+
+    "${isql_command[@]}" "$@"
+}
+
+# Execute database initialization scripts
+init_db() {
+    # Guard against empty glob (no files match)
+    if ! compgen -G "$1" > /dev/null 2>&1; then
+        return
+    fi
+
+    local f
+    for f; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    # Script is executable. Run it.
+                    printf '  running %s\n' "$f"
+                    "$f"
+                else
+                    # Script is not executable. Source it.
+                    printf '  sourcing %s\n' "$f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)     printf '  running %s\n' "$f"; cat "$f" | process_sql; printf '\n' ;;
+            *.sql.gz)  printf '  running %s\n' "$f"; gunzip -c "$f" | process_sql; printf '\n' ;;
+            *.sql.xz)  printf '  running %s\n' "$f"; xzcat "$f" | process_sql; printf '\n' ;;
+            *.sql.zst) printf '  running %s\n' "$f"; zstd -dc "$f" | process_sql; printf '\n' ;;
+            *)         printf '  ignoring %s\n' "$f" ;;
+        esac
+        printf '\n'
+    done
+}
+
+# Create user database.
+create_db() {
+    read_from_file_or_env 'FIREBIRD_DATABASE'
+    if [ -n "$FIREBIRD_DATABASE" ]; then
+        # Expand FIREBIRD_DATABASE to full path
+        cd "$FIREBIRD_DATA"
+        export FIREBIRD_DATABASE=$(realpath --canonicalize-missing "$FIREBIRD_DATABASE")
+
+        # Store it for other sessions of this instance (append, do not overwrite)
+        echo "export FIREBIRD_DATABASE='$FIREBIRD_DATABASE'" >> /opt/firebird/.firebird_env
+
+        # Create database only if not exists.
+        if [ ! -f "$FIREBIRD_DATABASE" ]; then
+            echo "Creating database '$FIREBIRD_DATABASE'..."
+
+            read_from_file_or_env 'FIREBIRD_DATABASE_PAGE_SIZE'
+            read_from_file_or_env 'FIREBIRD_DATABASE_DEFAULT_CHARSET'
+
+            local escaped_database
+            escaped_database=$(escape_sql_string "$FIREBIRD_DATABASE")
+
+            local user_and_password=''
+            if [ -n "$FIREBIRD_USER" ]; then
+                local escaped_user
+                escaped_user=$(escape_sql_string "$FIREBIRD_USER")
+                local escaped_password
+                escaped_password=$(escape_sql_string "$FIREBIRD_PASSWORD")
+                user_and_password=" USER '${escaped_user}' PASSWORD '${escaped_password}'"
+            fi
+
+            local page_size=''
+            [ -n "$FIREBIRD_DATABASE_PAGE_SIZE" ] && page_size="PAGE_SIZE $FIREBIRD_DATABASE_PAGE_SIZE"
+
+            local default_charset=''
+            [ -n "$FIREBIRD_DATABASE_DEFAULT_CHARSET" ] && default_charset="DEFAULT CHARACTER SET $FIREBIRD_DATABASE_DEFAULT_CHARSET"
+
+            # [Tabs ahead]
+            /opt/firebird/bin/isql -b -q <<-EOL
+			CREATE DATABASE '${escaped_database}'
+			    $user_and_password
+			    $page_size
+			    $default_charset;
+			EXIT;
+			EOL
+
+            init_db /docker-entrypoint-initdb.d/*
+        fi
+    fi
+}
+
+sigint_handler() {
+    echo "Stopping Firebird... [SIGINT received]"
+}
+
+sigterm_handler() {
+    echo "Stopping Firebird... [SIGTERM received]"
+}
+
+run_daemon_and_wait() {
+    # Traps SIGINT (handles Ctrl-C in interactive mode)
+    trap sigint_handler SIGINT
+
+    # Traps SIGTERM (polite shutdown)
+    trap sigterm_handler SIGTERM
+
+    # Firebird version
+    echo -n 'Starting '
+    /opt/firebird/bin/firebird -z
+
+    # Run fbguard and wait
+    /opt/firebird/bin/fbguard &
+    wait $!
+}
+
+
+
+#
+# main()
+#
+if [ "$1" = 'firebird' ]; then
+    set_config
+    set_sysdba
+
+    create_user
+    create_db
+
+    run_daemon_and_wait
+else
+    exec "$@"
+fi

--- a/generated/4.0.0/bookworm/Dockerfile
+++ b/generated/4.0.0/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.0/bullseye/Dockerfile
+++ b/generated/4.0.0/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.0/jammy/Dockerfile
+++ b/generated/4.0.0/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.0/noble/Dockerfile
+++ b/generated/4.0.0/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -72,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.0/trixie/Dockerfile
+++ b/generated/4.0.0/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.1/bookworm/Dockerfile
+++ b/generated/4.0.1/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.1/bullseye/Dockerfile
+++ b/generated/4.0.1/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.1/jammy/Dockerfile
+++ b/generated/4.0.1/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.1/noble/Dockerfile
+++ b/generated/4.0.1/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -72,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.1/trixie/Dockerfile
+++ b/generated/4.0.1/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.2/bookworm/Dockerfile
+++ b/generated/4.0.2/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.2/bullseye/Dockerfile
+++ b/generated/4.0.2/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.2/jammy/Dockerfile
+++ b/generated/4.0.2/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.2/noble/Dockerfile
+++ b/generated/4.0.2/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -72,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.2/trixie/Dockerfile
+++ b/generated/4.0.2/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.3/bookworm/Dockerfile
+++ b/generated/4.0.3/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.3/bullseye/Dockerfile
+++ b/generated/4.0.3/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.3/jammy/Dockerfile
+++ b/generated/4.0.3/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.3/noble/Dockerfile
+++ b/generated/4.0.3/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -72,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.3/trixie/Dockerfile
+++ b/generated/4.0.3/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.4/bookworm/Dockerfile
+++ b/generated/4.0.4/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.4/bullseye/Dockerfile
+++ b/generated/4.0.4/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.4/jammy/Dockerfile
+++ b/generated/4.0.4/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.4/noble/Dockerfile
+++ b/generated/4.0.4/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -72,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.4/trixie/Dockerfile
+++ b/generated/4.0.4/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.5/bookworm/Dockerfile
+++ b/generated/4.0.5/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.5/bullseye/Dockerfile
+++ b/generated/4.0.5/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.5/jammy/Dockerfile
+++ b/generated/4.0.5/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.5/noble/Dockerfile
+++ b/generated/4.0.5/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -72,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.5/trixie/Dockerfile
+++ b/generated/4.0.5/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.6/bookworm/Dockerfile
+++ b/generated/4.0.6/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.6/bullseye/Dockerfile
+++ b/generated/4.0.6/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.6/jammy/Dockerfile
+++ b/generated/4.0.6/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.6/noble/Dockerfile
+++ b/generated/4.0.6/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -72,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.6/trixie/Dockerfile
+++ b/generated/4.0.6/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.7/bookworm/Dockerfile
+++ b/generated/4.0.7/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.7/bullseye/Dockerfile
+++ b/generated/4.0.7/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.7/jammy/Dockerfile
+++ b/generated/4.0.7/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -73,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.7/noble/Dockerfile
+++ b/generated/4.0.7/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -72,6 +72,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/4.0.7/trixie/Dockerfile
+++ b/generated/4.0.7/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=4
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.0/bookworm/Dockerfile
+++ b/generated/5.0.0/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.0/bullseye/Dockerfile
+++ b/generated/5.0.0/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.0/jammy/Dockerfile
+++ b/generated/5.0.0/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -77,6 +76,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.0/noble/Dockerfile
+++ b/generated/5.0.0/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -76,6 +76,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.0/trixie/Dockerfile
+++ b/generated/5.0.0/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.1/bookworm/Dockerfile
+++ b/generated/5.0.1/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.1/bullseye/Dockerfile
+++ b/generated/5.0.1/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.1/jammy/Dockerfile
+++ b/generated/5.0.1/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -77,6 +76,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.1/noble/Dockerfile
+++ b/generated/5.0.1/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -76,6 +76,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.1/trixie/Dockerfile
+++ b/generated/5.0.1/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.2/bookworm/Dockerfile
+++ b/generated/5.0.2/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.2/bullseye/Dockerfile
+++ b/generated/5.0.2/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.2/jammy/Dockerfile
+++ b/generated/5.0.2/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -77,6 +76,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.2/noble/Dockerfile
+++ b/generated/5.0.2/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -76,6 +76,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.2/trixie/Dockerfile
+++ b/generated/5.0.2/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.3/bookworm/Dockerfile
+++ b/generated/5.0.3/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.3/bullseye/Dockerfile
+++ b/generated/5.0.3/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.3/jammy/Dockerfile
+++ b/generated/5.0.3/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -77,6 +76,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.3/noble/Dockerfile
+++ b/generated/5.0.3/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -76,6 +76,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.3/trixie/Dockerfile
+++ b/generated/5.0.3/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.4/bookworm/Dockerfile
+++ b/generated/5.0.4/bookworm/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu72 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.4/bullseye/Dockerfile
+++ b/generated/5.0.4/bullseye/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu67 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.4/jammy/Dockerfile
+++ b/generated/5.0.4/jammy/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu70 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -77,6 +76,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.4/noble/Dockerfile
+++ b/generated/5.0.4/noble/Dockerfile
@@ -19,19 +19,19 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu74 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
         procps \
         tini \
+        tzdata \
         ca-certificates \
         curl; \
     \
@@ -76,6 +76,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/generated/5.0.4/trixie/Dockerfile
+++ b/generated/5.0.4/trixie/Dockerfile
@@ -19,14 +19,13 @@ ENV FIREBIRD_MAJOR=5
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         libicu76 \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -76,6 +75,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/src/Dockerfile.template
+++ b/src/Dockerfile.template
@@ -15,14 +15,13 @@ ENV FIREBIRD_MAJOR={{FIREBIRD_MAJOR}}
 #   -x  Print commands and their arguments as they are executed.
 
 # Prerequisites
-#   FB 3.0 uses libncurses5: https://github.com/FirebirdSQL/firebird/issues/6418#issuecomment-826245785
 RUN set -eux; \
     apt-get update; \
     # Install prerequisites + tini + curl/ca-certificates for download
     apt-get install -y --no-install-recommends \
         libatomic1 \
         {{ICU_PACKAGE}} \
-        $([ $FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6') \
+        libncurses6 \
         libtomcrypt1 \
         libtommath1 \
         netbase \
@@ -72,6 +71,49 @@ RUN set -eux; \
 RUN set -eux; \
     ARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "$(uname -m)-linux-gnu"); \
     [ $FIREBIRD_MAJOR -eq 3 ] && ln -sf /usr/lib/$ARCH/libtommath.so.1 /usr/lib/$ARCH/libtommath.so.0 || true
+
+# FB 3.0 needs libncurses5/libtinfo5. On Debian Trixie and Ubuntu Noble those
+# packages were dropped from apt; pull them from the previous release pool.
+# See DECISIONS.md D-017 and https://github.com/FirebirdSQL/firebird-docker/issues/42
+RUN set -eux; \
+    if [ "$FIREBIRD_MAJOR" = "3" ]; then \
+        . /etc/os-release; \
+        case "$ID-$VERSION_CODENAME" in \
+            debian-bookworm|debian-bullseye|ubuntu-jammy) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends libtinfo5 libncurses5; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            debian-trixie) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.4-4_amd64.deb; \
+                curl -fSL -O http://deb.debian.org/debian/pool/main/n/ncurses/libncurses5_6.4-4_amd64.deb; \
+                dpkg -i libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                rm -f libtinfo5_6.4-4_amd64.deb libncurses5_6.4-4_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            ubuntu-noble) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends ca-certificates curl; \
+                cd /tmp; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+                curl -fSL -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                rm -f libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb; \
+                apt-get purge -y --auto-remove curl ca-certificates; \
+                apt-get clean; \
+                rm -rf /var/lib/apt/lists/* \
+                ;; \
+            *) \
+                echo "FB3: no libncurses5 provisioning path for $ID-$VERSION_CODENAME" >&2; \
+                exit 1 \
+                ;; \
+        esac; \
+    fi
 
 # System path
 ENV PATH=/opt/firebird/bin:$PATH

--- a/src/README.md.template
+++ b/src/README.md.template
@@ -18,8 +18,6 @@ Docker images for Firebird Database.
 |:-|:-:|
 {{SupportedTags}}
 
-> _Firebird 3 does not have an image for Ubuntu 24.04 LTS (Noble Numbat) due to a dependency (`libncurses5`) missing from Ubuntu sources._
-
 
 ## Snapshot (pre-release) images
 


### PR DESCRIPTION
Fixes #42.

## Problem

The official Firebird 3 amd64 tarball links against `libncurses.so.5` / `libtinfo.so.5`. Debian Trixie and Ubuntu Noble both dropped the `libncurses5` / `libtinfo5` apt packages, so the existing FB3 Dockerfile (which `apt-get install`s `libncurses5`) cannot build on those distros. Until now the repo worked around this by excluding the combinations via `blockedVariants` in `assets.json` (D-007). Trixie is now the default distro (D-012), so leaving FB3 unsupported there is no longer an acceptable position.

Empirically verified during planning: `ldd` against every ELF in the unpacked Firebird-3.0.14 tarball shows `libncurses.so.5` is the only remaining unresolved dependency on Trixie and Noble — `libtommath.so.0` is already handled by the existing symlink in the Dockerfile (line 74). All other deps (libatomic1, libicu74/76, libtomcrypt1, libtommath1) are present on both distros.

## Fix

`src/Dockerfile.template` gains a new RUN step, gated on `FIREBIRD_MAJOR == 3`, that detects the distro via `/etc/os-release` and provisions `libncurses5` + `libtinfo5`:

- **`debian-bookworm | debian-bullseye | ubuntu-jammy`** → `apt-get install -y --no-install-recommends libtinfo5 libncurses5` (unchanged behaviour, just relocated out of the main apt step).
- **`debian-trixie`** → `curl` + `dpkg -i` of `libtinfo5_6.4-4_amd64.deb` and `libncurses5_6.4-4_amd64.deb` from the bookworm pool at `deb.debian.org`.
- **`ubuntu-noble`** → `curl` + `dpkg -i` of `libtinfo5_6.3-2ubuntu0.1_amd64.deb` and `libncurses5_6.3-2ubuntu0.1_amd64.deb` from the jammy/universe pool at `archive.ubuntu.com`.
- **anything else** → build fails with a clear message (not a silent skip).

The previous `$([ \$FIREBIRD_MAJOR -eq 3 ] && echo 'libncurses5' || echo 'libncurses6')` ternary on the main apt-get line is replaced with plain `libncurses6` — all five distros have it, and the new block now owns FB3-specific ncurses provisioning end-to-end.

`assets.json`:
- `blockedVariants` cleared (`{}`).
- Every FB3 patch release (3.0.9 → 3.0.14) gains `noble` and `trixie` entries in its `tags` map. 3.0.14 is latest-of-major, so its trixie entry carries the `3.0.14`, `3`, `3-trixie`, `3.0.14-trixie` aliases; its noble entry carries `3.0.14-noble`, `3-noble`. Older patches get `3.0.X-noble` and `[3.0.X-trixie, 3.0.X]` per the existing tag-shape convention.
- One related distro-config fix: `noble`'s `extraPackages` gains `tzdata`. FB3 uses libc `localtime()` for the `TZ` env var, which requires `/usr/share/zoneinfo`; the ubuntu:noble base image, like jammy, ships without it. FB4+ embeds its own zoneinfo and is unaffected, which is why the gap only surfaced when re-enabling FB3 builds on Noble. The matching `tzdata` package was already in jammy's `extraPackages`.

`DECISIONS.md` records this as D-017 and marks D-007 amended. `src/README.md.template` drops the now-stale "Firebird 3 does not have an image for Ubuntu 24.04 LTS" warning. `AGENTS.md` line 22 changes `Blocked: FB3 + noble (no libncurses5).` to `Blocked: none.`.

The new RUN block is text-present in all generated Dockerfiles (FB4/FB5 included) but is a no-op there because the outer `if [ "$FIREBIRD_MAJOR" = "3" ]` guard short-circuits. FB4 and FB5 image content is unchanged apart from the line-25 ternary collapsing to plain `libncurses6`.

## Test plan

Local (PowerShell on the contributor host):

- `Invoke-Build Prepare` and `Invoke-Build Update-Readme` produce a deterministic, idempotent diff (verified by SHA-256-ing `generated/` and `README.md` before and after a second run).
- Pester tag unit tests in `src/tags.tests.ps1`: 6/6 green.
- `Invoke-Build Build -VersionFilter '3.0.14' -DistributionFilter 'trixie'` and the matching `Invoke-Build Test`: 24/24 tests green.
- Same for `3.0.14` + `noble`: 24/24 tests green (only after the tzdata fix; the `TZ_can_change_system_timezone` test was the canary that surfaced the missing zoneinfo).
- Regression checks `3.0.14`+`bookworm` and `5.0.4`+`trixie`: both 24/24 green.

Fork CI (`fdcastel/firebird-docker-fork`, ci.yaml on push):

- [Run 25838222556](https://github.com/fdcastel/firebird-docker-fork/actions/runs/25838222556) — success.
- amd64 runner: build + test of `3.0.14`, `4.0.7`, `5.0.4` across all five distros — green.
- arm64 runner: same set; FB3/FB4 are amd64-only per D-015 so arm64 only exercises FB5 — green.
- Tag unit tests on the amd64 runner — green.

## Risks and follow-ups

- The `.deb` URLs are pinned to specific bookworm and jammy archive paths. Both pools remain populated through their respective LTS windows (~mid-2028 for bookworm, ~April 2032 for jammy ESM). If a future archive cycle removes a file, the URL can be repointed at `snapshot.debian.org` / `launchpad.net/+archive/...` from inside the same `case` block — no template restructuring required.
- The pre-existing stale comment `Default distro: bookworm` on the same `AGENTS.md` line as the `Blocked:` text is unrelated drift (the actual default is `trixie` per D-012); left for a separate PR rather than expanding scope.
- Verified that `src/tags.tests.ps1` does not assert anything about `blockedVariants` or FB3's absence from any distro — no test edits required for the unblock.